### PR TITLE
Split ranges > 1 year into first year + remainder

### DIFF
--- a/src/entsoe/query/decorators.py
+++ b/src/entsoe/query/decorators.py
@@ -34,7 +34,7 @@ def range_limited(func):
             logger.debug("No period parameters found, calling function directly")
             return func(params, *args, **kwargs)
 
-        logger.debug(f"range_limited decorator called for function: {func.__name__}")
+        logger.debug(f"Range_limited decorator called for function: {func.__name__}")
         logger.debug(f"Period range: {period_start} to {period_end}")
 
         # Check if the range exceeds the limit (1 year = 365 days)
@@ -42,7 +42,7 @@ def range_limited(func):
             logger.debug("Range exceeds 365 days, splitting range")
 
             # Split the range and make recursive calls
-            pivot_date, _ = split_date_range(period_start, period_end)
+            pivot_date = split_date_range(period_start, period_end)
             logger.debug(f"Split at pivot date: {pivot_date}")
 
             # Create new params for the first half
@@ -94,9 +94,8 @@ def acknowledgement(func):
                 logger.debug(f"{reason}\nReturning None")
                 return None, None
             else:
-                logger.debug(
-                    "Acknowledgement document indicates error, raising exception"
-                )
+                for reason in response.reason:
+                    logger.error(reason.text)
                 raise AcknowledgementDocumentError(response.reason)
 
         logger.debug("Acknowledgement check passed, returning response")

--- a/src/entsoe/utils/utils.py
+++ b/src/entsoe/utils/utils.py
@@ -1,5 +1,5 @@
 from dataclasses import fields, is_dataclass
-from datetime import datetime
+from datetime import datetime, timedelta
 import inspect
 from xml.etree import ElementTree as ET
 
@@ -70,30 +70,29 @@ def check_date_range_limit(
     return exceeds_limit
 
 
-def split_date_range(period_start: int, period_end: int) -> tuple[int, int]:
+def split_date_range(period_start: int, period_end: int) -> int:
     """
-    Split a date range into two equal parts.
+    Split a date range into the first 365 days and the remaining days.
 
     Args:
         period_start: Start date in YYYYMMDDHHMM format
         period_end: End date in YYYYMMDDHHMM format
 
     Returns:
-        Tuple of (pivot_date, end_date) where pivot_date is the midpoint
+        The pivot date (end of first segment) in YYYYMMDDHHMM format
     """
     logger.debug(f"Splitting date range: {period_start} to {period_end}")
 
     start_dt = parse_entsoe_datetime(period_start)
-    end_dt = parse_entsoe_datetime(period_end)
 
-    # Calculate the midpoint
-    diff = end_dt - start_dt
-    pivot_dt = start_dt + (diff / 2)
+    # Add 365 days to the start date
+    pivot_dt = start_dt + timedelta(days=365)
 
-    pivot_date = format_entsoe_datetime(pivot_dt)
-    logger.debug(f"Split result: pivot={pivot_date}, end={period_end}")
+    period_pivot = format_entsoe_datetime(pivot_dt)
 
-    return pivot_date, period_end
+    logger.debug(f"Split at {period_pivot}:")
+
+    return period_pivot
 
 
 def extract_namespace_and_find_classes(response) -> tuple[str, type]:

--- a/tests/test_logging.py
+++ b/tests/test_logging.py
@@ -33,7 +33,7 @@ class TestLogging:
     def test_split_date_range_logging(self):
         """Test that split_date_range logs debug messages."""
         with patch("entsoe.utils.utils.logger") as mock_logger:
-            pivot, end = split_date_range(202301010000, 202301050000)
+            pivot = split_date_range(202301010000, 202301050000)
             assert mock_logger.debug.called
             # Verify that logging calls mention the function purpose
             call_args = [call[0][0] for call in mock_logger.debug.call_args_list]


### PR DESCRIPTION
This PR fixes a subtle problem with the API and also reduces API requests by altering the splitting procedure for long date ranges.

Consider this request: 

```python
ActualTotalLoad(
    out_bidding_zone_domain="10Y1001A1001A39I",
    period_start=202009170000,
    period_end=202509171330,
).query_api()
```

It fails with: `AcknowledgementDocumentError: [Reason(code=<ReasonCodeTypeList.VALUE_999: '999'>, text='Delivered time interval is not valid for this Data item.')]`.

The reason is the half-hour that was queried in `period_end` (13:30). If we switch this to something sharp (13:00, 14:00 etc.), we get data and the error disappears.

```python 
ActualTotalLoad(
    out_bidding_zone_domain="10Y1001A1001A39I",
    period_start=202009170000,
    period_end=202509171330,
).query_api()
```

The current implementation often queries odd timestamps since we subsequently split long date ranges in half, thereby frequently introducing odd timestamps. Additionally, this subsequent halving creates more requests than necessary.
Consider a Request covering exactly 5 Years. We will recursively halve 3 times and then query 8 times 0.625 Years of data.

This PR alters the splitting to address the above. The new implementation divides the long-range data into the first 365 days and the remainder. This brings us down to 6 API requests in the above example and does not introduce odd timestamps.