### PR TITLE
fix: ProcuredBalancingCapacity Args

### DIFF
--- a/src/entsoe/Balancing/specific_params.py
+++ b/src/entsoe/Balancing/specific_params.py
@@ -534,7 +534,7 @@ class ProcuredBalancingCapacity(Balancing):
         Args:
             period_start: Start period (YYYYMMDDHHMM format)
             period_end: End period (YYYYMMDDHHMM format)
-            area_domain: EIC code of Bidding Zone or Market Balancing Area
+            area_domain: EIC code of Scheduling Area
             process_type: A46=RR, A47=mFRR, A51=aFRR, A52=FCR
             offset: Offset for pagination
         """


### PR DESCRIPTION
Dear @jiedxu @BerriJ,

Based on the [official documentation](https://documenter.getpostman.com/view/7009892/2s93JtP3F6#5acdefd7-94d6-4300-8077-ad1b4e0ce6d6), `bidding_zone_domain` should be replaced by `area_domain`. 

Otherwise, a query to the api will rise an Error 

> Mandatory parameter Area_Domain is missing

What do you think ?