### PR TITLE
Update extract_records function

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -29,6 +29,10 @@ records = add_timestamps(records)
 df = DataFrame(records)
 ```
 
+!!! note
+    The [`extract_records`](utilities.md#entsoe.utils.extract_records) function automatically removes `m_rid` and `time_series.m_rid` metadata fields. This mitigates duplicates due to internal splitting of queries, see [#68](https://github.com/BerriJ/entsoe-apy/issues/68). You may extend the `ignore_fields` parameter as needed (for exampe with `"created_date_time", "time_period_time_interval.start","time_period_time_interval.end"`).
+     See [`extract_records`](utilities.md#entsoe.utils.extract_records) for more details.
+
 See also [Utilities](./utilities.md) for more details on the utility functions.
 
 ### Extracting Specific Domains

--- a/src/entsoe/utils/records.py
+++ b/src/entsoe/utils/records.py
@@ -115,9 +115,6 @@ def extract_records(
     ignore_fields: Optional[List[str]] = [
         "m_rid",
         "time_series.m_rid",
-        "created_date_time",
-        "time_period_time_interval.start",
-        "time_period_time_interval.end",
     ],
     deduplicate: bool = True,
 ) -> List[Dict[str, int | float | str | None]]:
@@ -138,15 +135,12 @@ def extract_records(
                each BaseModel instance.
         ignore_fields: Optional list of field names to exclude from the flattened records.
                       Fields are matched by their full dotted path (e.g., "m_rid", "time_series.m_rid").
-                      Defaults to ["m_rid", "time_series.m_rid", "created_date_time",
-                      "time_period_time_interval.start", "time_period_time_interval.end"].
+                      Defaults to ["m_rid", "time_series.m_rid"].
                       Pass None to disable field filtering.
         deduplicate: Whether to remove duplicate records while preserving order. Defaults to True.
 
     Returns:
         List of flattened dictionaries (records) from all BaseModel instances.
-        Records from multiple models are concatenated in the order they appear,
-        with ignored fields removed and optionally duplicates eliminated while preserving order.
 
     Raises:
         KeyError: If specified domain is not found in the data


### PR DESCRIPTION
This adjusts the default of  `ignore_fields` in `extract_records` and adjusts documentation. The default was: 

```python
ignore_fields: Optional[List[str]] = [
        "m_rid",
        "time_series.m_rid",
        "created_date_time",
        "time_period_time_interval.start",
        "time_period_time_interval.end",
],
```

It's adjusted to:

https://github.com/BerriJ/entsoe-apy/blob/8a7db7c14c3b33f4038fc1e6a7a57365e36f13c4/src/entsoe/utils/records.py#L115-L118

While `created_date_time`, `time_period_time_interval.start`, and `time_period_time_interval.end` are not of interest for `EnergyPrices`, for example, they are of interest when inspecting outages. Therefore, we reduce the `ignore_fields` to an absolute minimum and move the responsibility of handling duplicates to the user. See  #68.
