### PR TITLE
Release 0.8.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
   {name="Jonathan Berrisch", email="jonathan.berrisch@uni-due.de"},
   {name="Jie Xu", email="jie.xu@uni-due.de"}
 ]
-version = "0.8.0"
+version = "0.8.1"
 description = "A Python library for accessing ENTSO-E Transparency Platform API endpoints"
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.8.0"
 description = "A Python library for accessing ENTSO-E Transparency Platform API endpoints"
 readme = "README.md"
 license = "GPL-3.0-or-later"
-requires-python = ">=3.11.0"
+requires-python = ">=3.11.0,<=3.13.0"
 keywords = ["entsoe", "energy", "electricity", "api", "transparency", "platform"]
 classifiers = [
   "Development Status :: 4 - Beta",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ version = "0.8.0"
 description = "A Python library for accessing ENTSO-E Transparency Platform API endpoints"
 readme = "README.md"
 license = "GPL-3.0-or-later"
-requires-python = ">=3.11.0,<=3.13.0"
+requires-python = ">=3.11.0,<3.14.0"
 keywords = ["entsoe", "energy", "electricity", "api", "transparency", "platform"]
 classifiers = [
   "Development Status :: 4 - Beta",

--- a/src/entsoe/Balancing/specific_params.py
+++ b/src/entsoe/Balancing/specific_params.py
@@ -85,9 +85,14 @@ class VolumesAndPricesOfContractedReserves(Balancing):
     - businessType: B95 (Procured capacity)
 
     Required parameters:
+    - type_marketagreement_type: A01=Daily, A02=Weekly, A03=Monthly, A04=Yearly,
+                                 A06=Long term, A13=Hourly
     - processType: A51=Automatic frequency restoration reserve,
                   A52=Frequency containment reserve, A47=Manual frequency
                   restoration reserve, A46=Replacement reserve
+
+    Optional parameters:
+    - psrType: A03=Mixed, A04=Generation, A05=Load
     """
 
     code = "17.1.B_C"
@@ -96,8 +101,11 @@ class VolumesAndPricesOfContractedReserves(Balancing):
         self,
         period_start: int,
         period_end: int,
-        bidding_zone_domain: str,
-        process_type: str,
+        control_area_domain: str,
+        type_marketagreement_type: str,
+        process_type: Optional[str] = None,
+        # Optional parameters
+        psr_type: Optional[str] = None,
         # Additional common parameters
         offset: int = 0,
     ):
@@ -107,8 +115,11 @@ class VolumesAndPricesOfContractedReserves(Balancing):
         Args:
             period_start: Start period (YYYYMMDDHHMM format)
             period_end: End period (YYYYMMDDHHMM format)
-            bidding_zone_domain: EIC code of Bidding Zone or Market Balancing Area
-            process_type: A51=aFRR, A52=FCR, A47=mFRR, A46=RR
+            control_area_domain: EIC code of a Scheduling Area
+            type_marketagreement_type: A01=Daily, A02=Weekly, A03=Monthly,
+                                       A04=Yearly, A06=Long term, A13=Hourly
+            process_type: A51=aFRR, A52=FCR, A47=mFRR, A46=RR (optional)
+            psr_type: A03=Mixed, A04=Generation, A05=Load (optional)
             offset: Offset for pagination
         """
         # Initialize with preset and user parameters
@@ -116,9 +127,11 @@ class VolumesAndPricesOfContractedReserves(Balancing):
             document_type="A81",
             period_start=period_start,
             period_end=period_end,
-            bidding_zone_domain=bidding_zone_domain,
+            control_area_domain=control_area_domain,
             business_type="B95",
+            type_marketagreement_type=type_marketagreement_type,
             process_type=process_type,
+            psr_type=psr_type,
             offset=offset,
         )
 
@@ -233,7 +246,7 @@ class FinancialExpensesAndIncomeForBalancing(Balancing):
         self,
         period_start: int,
         period_end: int,
-        bidding_zone_domain: str,
+        control_area_domain: str,
         # Additional common parameters
     ):
         """
@@ -242,14 +255,14 @@ class FinancialExpensesAndIncomeForBalancing(Balancing):
         Args:
             period_start: Start period (YYYYMMDDHHMM format)
             period_end: End period (YYYYMMDDHHMM format)
-            bidding_zone_domain: EIC code of Bidding Zone or Market Balancing Area
+            control_area_domain: EIC code of a Control Area or a Market Balance Area
         """
         # Initialize with preset and user parameters
         super().__init__(
             document_type="A87",
             period_start=period_start,
             period_end=period_end,
-            bidding_zone_domain=bidding_zone_domain,
+            control_area_domain=control_area_domain,
         )
 
 
@@ -421,6 +434,9 @@ class AllocationAndUseOfCrossZonalBalancingCapacity(Balancing):
     - processType: A46=Replacement reserve, A47=Manual frequency restoration reserve,
                   A51=Automatic frequency restoration reserve,
                   A52=Frequency containment reserve
+
+    Optional parameters:
+    - type_marketagreement_type: A01=Daily, A02=Weekly, A06=Long term
     """
 
     code = "12.3.H_I"
@@ -429,8 +445,11 @@ class AllocationAndUseOfCrossZonalBalancingCapacity(Balancing):
         self,
         period_start: int,
         period_end: int,
-        bidding_zone_domain: str,
+        connecting_domain: str,
+        acquiring_domain: str,
         process_type: str,
+        # Optional parameters
+        type_marketagreement_type: Optional[str] = None,
         # Additional common parameters
     ):
         """
@@ -439,16 +458,20 @@ class AllocationAndUseOfCrossZonalBalancingCapacity(Balancing):
         Args:
             period_start: Start period (YYYYMMDDHHMM format)
             period_end: End period (YYYYMMDDHHMM format)
-            bidding_zone_domain: EIC code of Bidding Zone or Market Balancing Area
+            connecting_domain: EIC code of a Bidding Zone
+            acquiring_domain: EIC code of a Bidding Zone
             process_type: A46=RR, A47=mFRR, A51=aFRR, A52=FCR
+            type_marketagreement_type: A01=Daily, A02=Weekly, A06=Long term (optional)
         """
         # Initialize with preset and user parameters
         super().__init__(
             document_type="A38",
             period_start=period_start,
             period_end=period_end,
-            bidding_zone_domain=bidding_zone_domain,
+            connecting_domain=connecting_domain,
+            acquiring_domain=acquiring_domain,
             process_type=process_type,
+            type_marketagreement_type=type_marketagreement_type,
         )
 
 
@@ -925,6 +948,7 @@ class CrossBorderMarginalPricesForAFRR(Balancing):
     - documentType: A84 (Activated balancing prices)
     - processType: A67 (Central Selection aFRR)
     - businessType: A96 (Automatic frequency restoration reserve)
+    - standard_market_product: A01 (Standard)
 
     Notes:
     - Specific to aFRR Central Selection marginal prices
@@ -937,7 +961,7 @@ class CrossBorderMarginalPricesForAFRR(Balancing):
         self,
         period_start: int,
         period_end: int,
-        bidding_zone_domain: str,
+        control_area_domain: str,
         # Additional common parameters
     ):
         """
@@ -946,16 +970,17 @@ class CrossBorderMarginalPricesForAFRR(Balancing):
         Args:
             period_start: Start period (YYYYMMDDHHMM format)
             period_end: End period (YYYYMMDDHHMM format)
-            bidding_zone_domain: EIC code of Bidding Zone or Market Balancing Area
+            control_area_domain: EIC code of a LFA, SCA, IPA
         """
         # Initialize with preset and user parameters
         super().__init__(
             document_type="A84",
             period_start=period_start,
             period_end=period_end,
-            bidding_zone_domain=bidding_zone_domain,
+            control_area_domain=control_area_domain,
             process_type="A67",
             business_type="A96",
+            standard_market_product="A01",
         )
 
 
@@ -1077,7 +1102,7 @@ class ElasticDemands(Balancing):
         self,
         period_start: int,
         period_end: int,
-        bidding_zone_domain: str,
+        acquiring_domain: str,
         process_type: str,
         # Additional common parameters
         offset: int = 0,
@@ -1088,7 +1113,7 @@ class ElasticDemands(Balancing):
         Args:
             period_start: Start period (YYYYMMDDHHMM format)
             period_end: End period (YYYYMMDDHHMM format)
-            bidding_zone_domain: EIC code of Bidding Zone or Market Balancing Area
+            acquiring_domain: EIC code of a Scheduling Area
             process_type: A51=aFRR, A47=mFRR
             offset: Offset for pagination
         """
@@ -1097,7 +1122,7 @@ class ElasticDemands(Balancing):
             document_type="A37",
             period_start=period_start,
             period_end=period_end,
-            bidding_zone_domain=bidding_zone_domain,
+            acquiring_domain=acquiring_domain,
             business_type="B75",
             process_type=process_type,
             offset=offset,

--- a/src/entsoe/Balancing/specific_params.py
+++ b/src/entsoe/Balancing/specific_params.py
@@ -87,12 +87,12 @@ class VolumesAndPricesOfContractedReserves(Balancing):
     Required parameters:
     - type_marketagreement_type: A01=Daily, A02=Weekly, A03=Monthly, A04=Yearly,
                                  A06=Long term, A13=Hourly
-    - processType: A51=Automatic frequency restoration reserve,
-                  A52=Frequency containment reserve, A47=Manual frequency
-                  restoration reserve, A46=Replacement reserve
 
     Optional parameters:
     - psrType: A03=Mixed, A04=Generation, A05=Load
+    - processType: A51=Automatic frequency restoration reserve,
+                  A52=Frequency containment reserve, A47=Manual frequency
+                  restoration reserve, A46=Replacement reserve
     """
 
     code = "17.1.B_C"
@@ -192,7 +192,7 @@ class TotalImbalanceVolumes(Balancing):
     - documentType: A86 (Imbalance volume)
 
     Optional parameters:
-    - businessType: A19=Balance Energy Deviation (default when not specified)
+    - businessType: A19=Balance Energy Deviation
     """
 
     code = "17.1.H"
@@ -213,7 +213,7 @@ class TotalImbalanceVolumes(Balancing):
             period_start: Start period (YYYYMMDDHHMM format)
             period_end: End period (YYYYMMDDHHMM format)
             control_area_domain: EIC code of Scheduling Area or Market Balance Area
-            business_type: A19=Balance Energy Deviation (default)
+            business_type: A19=Balance Energy Deviation
         """
         # Initialize with preset and user parameters
         super().__init__(

--- a/src/entsoe/Base/Balancing.py
+++ b/src/entsoe/Base/Balancing.py
@@ -24,7 +24,7 @@ class Balancing(Base):
         business_type: Optional[str] = None,
         process_type: Optional[str] = None,
         psr_type: Optional[str] = None,
-        type_marketplace_agreement_type: Optional[str] = None,
+        type_marketagreement_type: Optional[str] = None,
         standard_market_product: Optional[str] = None,
         original_market_product: Optional[str] = None,
         direction: Optional[str] = None,
@@ -55,7 +55,7 @@ class Balancing(Base):
             process_type: Process type (e.g., A01, A02, A16, A18, A31, A32, A33,
                          A39, A40, A44, A46, A47, A51, A52)
             psr_type: Power system resource type (A03, A04, A05, B01-B24)
-            type_marketplace_agreement_type: Type marketplace agreement (A01-A07)
+            type_marketagreement_type: Type market agreement (A01-A07)
             standard_market_product: Standard market product (A01-A07)
             original_market_product: Original market product (A02-A04)
             direction: Direction (A01=Up, A02=Down)
@@ -104,9 +104,7 @@ class Balancing(Base):
         )
 
         # Add market parameters
-        self.add_market_params(
-            type_marketplace_agreement_type=type_marketplace_agreement_type
-        )
+        self.add_market_params(type_marketagreement_type=type_marketagreement_type)
 
         # Add balancing-specific parameters
         self.add_balancing_params(

--- a/src/entsoe/Base/Base.py
+++ b/src/entsoe/Base/Base.py
@@ -200,7 +200,7 @@ class Base:
         contract_market_agreement_type: Optional[str] = None,
         auction_type: Optional[str] = None,
         auction_category: Optional[str] = None,
-        type_marketplace_agreement_type: Optional[str] = None,
+        type_marketagreement_type: Optional[str] = None,
     ) -> None:
         """
         Add market-related parameters to the params dictionary.
@@ -209,16 +209,14 @@ class Base:
             contract_market_agreement_type: Contract market agreement type
             auction_type: Auction type
             auction_category: Auction category
-            type_marketplace_agreement_type: Type marketplace agreement
+            type_marketagreement_type: Type market agreement
         """
         self.add_optional_param(
             "contract_MarketAgreement.Type", contract_market_agreement_type
         )
         self.add_optional_param("auction.Type", auction_type)
         self.add_optional_param("auction.category", auction_category)
-        self.add_optional_param(
-            "type_MarketAgreement.Type", type_marketplace_agreement_type
-        )
+        self.add_optional_param("type_MarketAgreement.Type", type_marketagreement_type)
 
     def add_balancing_params(
         self,

--- a/src/entsoe/Market/specific_params.py
+++ b/src/entsoe/Market/specific_params.py
@@ -231,7 +231,15 @@ class TotalCapacityAllocated(Market):
     Fixed parameters:
 
     - documentType: A26 (Capacity document)
-    - businessType: B07 (Total allocated capacity)
+    - businessType: A29 (Already Allocated Capacity)
+
+    Required parameters:
+    - contract_market_agreement_type: A01=Daily, A02=Weekly, A03=Monthly,
+                                      A04=Yearly, A06=Long Term, A07=Intraday,
+                                      A08=Quarterly
+
+    Optional parameters:
+    - auction_category: A01=Base, A02=Peak, A03=Off Peak, A04=Hourly
     """
 
     code = "12.1.C"
@@ -242,7 +250,11 @@ class TotalCapacityAllocated(Market):
         period_end: int,
         in_domain: str,
         out_domain: str,
-        contract_market_agreement_type: Optional[Literal["A01", "A07"]] = None,
+        contract_market_agreement_type: Literal[
+            "A01", "A02", "A03", "A04", "A06", "A07", "A08"
+        ],
+        # Optional parameters
+        auction_category: Optional[Literal["A01", "A02", "A03", "A04"]] = None,
         # Additional common parameters
     ):
         """
@@ -251,9 +263,12 @@ class TotalCapacityAllocated(Market):
         Args:
             period_start: Start period (YYYYMMDDHHMM format)
             period_end: End period (YYYYMMDDHHMM format)
-            in_domain: EIC code of a Control Area or Bidding Zone
-            out_domain: EIC code of a Control Area or Bidding Zone
-            contract_market_agreement_type: A01=Daily; A07=Intraday
+            in_domain: EIC code of a Control Area, Bidding Zone or Bidding Zone Aggregation
+            out_domain: EIC code of a Control Area, Bidding Zone or Bidding Zone Aggregation
+            contract_market_agreement_type: A01=Daily, A02=Weekly, A03=Monthly,
+                                           A04=Yearly, A06=Long Term, A07=Intraday,
+                                           A08=Quarterly
+            auction_category: A01=Base, A02=Peak, A03=Off Peak, A04=Hourly (optional)
         """
         # Initialize with preset and user parameters
         super().__init__(
@@ -262,8 +277,9 @@ class TotalCapacityAllocated(Market):
             period_end=period_end,
             in_domain=in_domain,
             out_domain=out_domain,
-            business_type="B07",  # Fixed: Total allocated capacity
+            business_type="A29",  # Fixed: Already Allocated Capacity
             contract_market_agreement_type=contract_market_agreement_type,
+            auction_category=auction_category,
         )
 
         self.validate_eic_equality(in_domain, out_domain, must_be_equal=False)
@@ -384,8 +400,15 @@ class ContinuousAllocationsOfferedCapacity(Market):
 
     Fixed parameters:
 
-    - documentType: B33 (Continuous capacity document)
     - auction_Type: A08 (Continuous)
+
+    Required parameters:
+    - document_type: A31=Agreed capacity (intermediate OC values),
+                    B33=Published offered capacity (most recent published OC values)
+
+    Notes:
+    - A31 provides intermediate OC values
+    - B33 provides most recent published OC values (default)
     """
 
     code = "11.1"
@@ -396,6 +419,8 @@ class ContinuousAllocationsOfferedCapacity(Market):
         period_end: int,
         in_domain: str,
         out_domain: str,
+        # Document type selection
+        document_type: Literal["A31", "B33"] = "B33",
         # Continuous is typically intraday
         contract_market_agreement_type: Literal["A07"] = "A07",
         business_type: Optional[str] = None,
@@ -411,6 +436,7 @@ class ContinuousAllocationsOfferedCapacity(Market):
             period_end: End period (YYYYMMDDHHMM format)
             in_domain: EIC code of Control Area, Bidding Zone or Aggregation
             out_domain: EIC code of Control Area, Bidding Zone or Aggregation
+            document_type: A31=Agreed capacity (intermediate), B33=Published offered capacity (default)
             contract_market_agreement_type: A07=Intraday (Continuous)
             business_type: Business type (e.g., A31)
             update_date_and_or_time: Update date and time filter
@@ -418,7 +444,7 @@ class ContinuousAllocationsOfferedCapacity(Market):
         """
         # Initialize with preset and user parameters
         super().__init__(
-            document_type="B33",  # Fixed: Continuous capacity document
+            document_type=document_type,  # A31 or B33
             period_start=period_start,
             period_end=period_end,
             in_domain=in_domain,
@@ -444,7 +470,10 @@ class ExplicitAllocationsUseTransferCapacity(Market):
     Fixed parameters:
 
     - documentType: A25 (Allocation result document)
-    - businessType: B05 (Capacity allocated including price)
+
+    Required parameters:
+    - businessType: A43=Requested capacity (without price),
+                   B05=Capacity allocated (including price)
     """
 
     code = "12.1.A"
@@ -458,6 +487,7 @@ class ExplicitAllocationsUseTransferCapacity(Market):
         contract_market_agreement_type: Literal[
             "A01", "A02", "A03", "A04", "A06", "A07", "A08"
         ] = "A07",
+        business_type: Literal["A43", "B05"] = "B05",
         auction_category: Optional[str] = None,
         classification_sequence_position: Optional[int] = None,
         # Additional common parameters
@@ -473,8 +503,10 @@ class ExplicitAllocationsUseTransferCapacity(Market):
             out_domain: EIC code of a Control Area, Bidding Zone or
                 Bidding Zone Aggregation
             contract_market_agreement_type: A01=Day ahead; A02=Weekly;
-                A03=Monthly; A04=Yearly; A06=Long Term; A07=Intraday;
+                A03=Monthly; A04=Yearly; A06=Long Term; A07=Intraday (default);
                 A08=Quarterly
+            business_type: A43=Requested capacity (without price),
+                          B05=Capacity allocated (including price, default)
             auction_category: Auction category (e.g., A04=Hourly)
             classification_sequence_position: Integer for classification
         """
@@ -485,7 +517,7 @@ class ExplicitAllocationsUseTransferCapacity(Market):
             period_end=period_end,
             in_domain=in_domain,
             out_domain=out_domain,
-            business_type="B05",  # Fixed: Capacity allocated (including price)
+            business_type=business_type,
             contract_market_agreement_type=contract_market_agreement_type,
             auction_category=auction_category,
         )

--- a/src/entsoe/Market/specific_params.py
+++ b/src/entsoe/Market/specific_params.py
@@ -408,7 +408,7 @@ class ContinuousAllocationsOfferedCapacity(Market):
 
     Notes:
     - A31 provides intermediate OC values
-    - B33 provides most recent published OC values (default)
+    - B33 provides most recent published OC values
     """
 
     code = "11.1"
@@ -420,7 +420,7 @@ class ContinuousAllocationsOfferedCapacity(Market):
         in_domain: str,
         out_domain: str,
         # Document type selection
-        document_type: Literal["A31", "B33"] = "B33",
+        document_type: Literal["A31", "B33"],
         # Continuous is typically intraday
         contract_market_agreement_type: Literal["A07"] = "A07",
         business_type: Optional[str] = None,
@@ -436,7 +436,7 @@ class ContinuousAllocationsOfferedCapacity(Market):
             period_end: End period (YYYYMMDDHHMM format)
             in_domain: EIC code of Control Area, Bidding Zone or Aggregation
             out_domain: EIC code of Control Area, Bidding Zone or Aggregation
-            document_type: A31=Agreed capacity (intermediate), B33=Published offered capacity (default)
+            document_type: A31=Agreed capacity (intermediate), B33=Published offered capacity
             contract_market_agreement_type: A07=Intraday (Continuous)
             business_type: Business type (e.g., A31)
             update_date_and_or_time: Update date and time filter
@@ -444,14 +444,14 @@ class ContinuousAllocationsOfferedCapacity(Market):
         """
         # Initialize with preset and user parameters
         super().__init__(
-            document_type=document_type,  # A31 or B33
+            document_type=document_type,
             period_start=period_start,
             period_end=period_end,
             in_domain=in_domain,
             out_domain=out_domain,
             business_type=business_type,
             contract_market_agreement_type=contract_market_agreement_type,
-            auction_type="A08",  # Fixed: Continuous
+            auction_type="A08",
             offset=offset,
         )
 
@@ -486,8 +486,8 @@ class ExplicitAllocationsUseTransferCapacity(Market):
         out_domain: str,
         contract_market_agreement_type: Literal[
             "A01", "A02", "A03", "A04", "A06", "A07", "A08"
-        ] = "A07",
-        business_type: Literal["A43", "B05"] = "B05",
+        ],
+        business_type: Literal["A43", "B05"],
         auction_category: Optional[str] = None,
         classification_sequence_position: Optional[int] = None,
         # Additional common parameters
@@ -503,10 +503,10 @@ class ExplicitAllocationsUseTransferCapacity(Market):
             out_domain: EIC code of a Control Area, Bidding Zone or
                 Bidding Zone Aggregation
             contract_market_agreement_type: A01=Day ahead; A02=Weekly;
-                A03=Monthly; A04=Yearly; A06=Long Term; A07=Intraday (default);
+                A03=Monthly; A04=Yearly; A06=Long Term; A07=Intraday;
                 A08=Quarterly
             business_type: A43=Requested capacity (without price),
-                          B05=Capacity allocated (including price, default)
+                          B05=Capacity allocated (including price)
             auction_category: Auction category (e.g., A04=Hourly)
             classification_sequence_position: Integer for classification
         """

--- a/src/entsoe/Transmission/specific_params.py
+++ b/src/entsoe/Transmission/specific_params.py
@@ -106,7 +106,7 @@ class CommercialSchedules(Transmission):
         self.validate_eic_equality(in_domain, out_domain, must_be_equal=False)
 
         # Add contract market agreement type parameter
-        if contract_market_agreement_type:
+        if contract_market_agreement_type is not None:
             self.add_optional_param(
                 "contract_MarketAgreement.Type", contract_market_agreement_type
             )
@@ -163,11 +163,9 @@ class ForecastedTransferCapacities(Transmission):
 
         self.validate_eic_equality(in_domain, out_domain, must_be_equal=False)
 
-        # Add contract market agreement type parameter
-        if contract_market_agreement_type:
-            self.add_optional_param(
-                "contract_MarketAgreement.Type", contract_market_agreement_type
-            )
+        self.add_optional_param(
+            "contract_MarketAgreement.Type", contract_market_agreement_type
+        )
 
 
 class CommercialSchedulesNetPositions(Transmission):

--- a/src/entsoe/Transmission/specific_params.py
+++ b/src/entsoe/Transmission/specific_params.py
@@ -5,7 +5,7 @@ endpoints, each inheriting from TransmissionParams and providing preset values f
 fixed parameters.
 """
 
-from typing import Optional
+from typing import Literal, Optional
 
 from ..Base.Transmission import Transmission
 
@@ -63,7 +63,10 @@ class CommercialSchedules(Transmission):
     Fixed parameters:
 
     - documentType: A09 (Finalised schedule)
-    - contract_MarketAgreement.Type: A01 (Daily)
+
+    Optional parameters:
+    - contract_MarketAgreement.Type: A01=Day Ahead Commercial Schedules,
+                                      A05=Total Commercial Schedules
 
     Request Limits:
     - One year range limit applies
@@ -78,6 +81,7 @@ class CommercialSchedules(Transmission):
         period_end: int,
         out_domain: str,
         in_domain: str,
+        contract_market_agreement_type: Optional[Literal["A01", "A05"]] = "A01",
     ):
         """
         Initialize commercial schedules parameters.
@@ -86,7 +90,10 @@ class CommercialSchedules(Transmission):
             period_start: Start period (YYYYMMDDHHMM format)
             period_end: End period (YYYYMMDDHHMM format)
             out_domain: EIC code of output domain/bidding zone
-            in_domain: EIC code of input domain/bidding zone"""
+            in_domain: EIC code of input domain/bidding zone
+            contract_market_agreement_type: A01=Day Ahead Commercial Schedules (default),
+                                           A05=Total Commercial Schedules (optional)
+        """
         # Initialize with preset and user parameters
         super().__init__(
             document_type="A09",
@@ -98,8 +105,11 @@ class CommercialSchedules(Transmission):
 
         self.validate_eic_equality(in_domain, out_domain, must_be_equal=False)
 
-        # Add specific parameters
-        self.add_optional_param("contract_MarketAgreement.Type", "A01")
+        # Add contract market agreement type parameter
+        if contract_market_agreement_type:
+            self.add_optional_param(
+                "contract_MarketAgreement.Type", contract_market_agreement_type
+            )
 
 
 class ForecastedTransferCapacities(Transmission):
@@ -111,7 +121,10 @@ class ForecastedTransferCapacities(Transmission):
     Fixed parameters:
 
     - documentType: A61 (Estimated Net Transfer Capacity)
-    - contract_MarketAgreement.Type: A01 (Daily)
+
+    Required parameters:
+    - contract_MarketAgreement.Type: A01=Day ahead, A02=Week ahead,
+                                      A03=Month ahead, A04=Year ahead
 
     Request Limits:
     - One year range limit applies
@@ -126,6 +139,7 @@ class ForecastedTransferCapacities(Transmission):
         period_end: int,
         out_domain: str,
         in_domain: str,
+        contract_market_agreement_type: Literal["A01", "A02", "A03", "A04"] = "A01",
     ):
         """
         Initialize forecasted transfer capacities parameters.
@@ -134,7 +148,10 @@ class ForecastedTransferCapacities(Transmission):
             period_start: Start period (YYYYMMDDHHMM format)
             period_end: End period (YYYYMMDDHHMM format)
             out_domain: EIC code of output domain/bidding zone
-            in_domain: EIC code of input domain/bidding zone"""
+            in_domain: EIC code of input domain/bidding zone
+            contract_market_agreement_type: A01=Day ahead (default), A02=Week ahead,
+                                           A03=Month ahead, A04=Year ahead
+        """
         # Initialize with preset and user parameters
         super().__init__(
             document_type="A61",
@@ -146,8 +163,10 @@ class ForecastedTransferCapacities(Transmission):
 
         self.validate_eic_equality(in_domain, out_domain, must_be_equal=False)
 
-        # Add specific parameters
-        self.add_optional_param("contract_MarketAgreement.Type", "A01")
+        # Add contract market agreement type parameter
+        self.add_optional_param(
+            "contract_MarketAgreement.Type", contract_market_agreement_type
+        )
 
 
 class CommercialSchedulesNetPositions(Transmission):

--- a/src/entsoe/Transmission/specific_params.py
+++ b/src/entsoe/Transmission/specific_params.py
@@ -81,7 +81,7 @@ class CommercialSchedules(Transmission):
         period_end: int,
         out_domain: str,
         in_domain: str,
-        contract_market_agreement_type: Optional[Literal["A01", "A05"]] = "A01",
+        contract_market_agreement_type: Optional[Literal["A01", "A05"]] = None,
     ):
         """
         Initialize commercial schedules parameters.
@@ -91,7 +91,7 @@ class CommercialSchedules(Transmission):
             period_end: End period (YYYYMMDDHHMM format)
             out_domain: EIC code of output domain/bidding zone
             in_domain: EIC code of input domain/bidding zone
-            contract_market_agreement_type: A01=Day Ahead Commercial Schedules (default),
+            contract_market_agreement_type: A01=Day Ahead Commercial Schedules,
                                            A05=Total Commercial Schedules (optional)
         """
         # Initialize with preset and user parameters
@@ -139,7 +139,7 @@ class ForecastedTransferCapacities(Transmission):
         period_end: int,
         out_domain: str,
         in_domain: str,
-        contract_market_agreement_type: Literal["A01", "A02", "A03", "A04"] = "A01",
+        contract_market_agreement_type: Literal["A01", "A02", "A03", "A04"],
     ):
         """
         Initialize forecasted transfer capacities parameters.
@@ -149,7 +149,7 @@ class ForecastedTransferCapacities(Transmission):
             period_end: End period (YYYYMMDDHHMM format)
             out_domain: EIC code of output domain/bidding zone
             in_domain: EIC code of input domain/bidding zone
-            contract_market_agreement_type: A01=Day ahead (default), A02=Week ahead,
+            contract_market_agreement_type: A01=Day ahead, A02=Week ahead,
                                            A03=Month ahead, A04=Year ahead
         """
         # Initialize with preset and user parameters
@@ -164,9 +164,10 @@ class ForecastedTransferCapacities(Transmission):
         self.validate_eic_equality(in_domain, out_domain, must_be_equal=False)
 
         # Add contract market agreement type parameter
-        self.add_optional_param(
-            "contract_MarketAgreement.Type", contract_market_agreement_type
-        )
+        if contract_market_agreement_type:
+            self.add_optional_param(
+                "contract_MarketAgreement.Type", contract_market_agreement_type
+            )
 
 
 class CommercialSchedulesNetPositions(Transmission):

--- a/src/entsoe/config/config.py
+++ b/src/entsoe/config/config.py
@@ -88,7 +88,7 @@ class EntsoEConfig:
         self,
         security_token: Optional[str] = None,
         endpoint_url: Optional[str] = None,
-        timeout: int = 5,
+        timeout: int = 20,
         retries: int = 5,
         retry_delay: Union[int, Callable[[int], int]] = lambda attempt: 2**attempt,
         max_workers: int = 4,
@@ -104,7 +104,7 @@ class EntsoEConfig:
             endpoint_url: API endpoint URL. If not provided, will try to get from
                          ENTSOE_ENDPOINT_URL environment variable. If neither is available,
                          defaults to "https://web-api.tp.entsoe.eu/api".
-            timeout: Request timeout in seconds (default: 5)
+            timeout: Request timeout in seconds (default: 20)
             retries: Number of retry attempts for failed requests (default: 5)
             retry_delay: Function that takes attempt number and returns delay in seconds,
                         or integer for constant delay (default: exponential backoff 2**attempt)
@@ -223,7 +223,7 @@ def get_config() -> EntsoEConfig:
 def set_config(
     security_token: Optional[str] = None,
     endpoint_url: Optional[str] = None,
-    timeout: int = 5,
+    timeout: int = 20,
     retries: int = 5,
     retry_delay: Union[int, Callable[[int], int]] = lambda attempt: 2**attempt,
     max_workers: int = 4,
@@ -238,7 +238,7 @@ def set_config(
         endpoint_url: API endpoint URL. If not provided, will try to get from
                      ENTSOE_ENDPOINT_URL environment variable. If neither is available,
                      defaults to "https://web-api.tp.entsoe.eu/api".
-        timeout: Request timeout in seconds (default: 5)
+        timeout: Request timeout in seconds (default: 20)
         retries: Number of retry attempts for failed requests (default: 5)
         retry_delay: Function that takes attempt number and returns delay in seconds,
                     or integer for constant delay (default: exponential backoff 2**attempt)

--- a/tests/test_eic_equality_validation.py
+++ b/tests/test_eic_equality_validation.py
@@ -200,6 +200,7 @@ class TestEICEqualityValidation:
             period_end=202101022300,
             in_domain="10YGB----------A",
             out_domain="10YFR-RTE------C",
+            contract_market_agreement_type="A01",
         )
         assert capacities.params["in_Domain"] == "10YGB----------A"
         assert capacities.params["out_Domain"] == "10YFR-RTE------C"
@@ -211,6 +212,7 @@ class TestEICEqualityValidation:
                 period_end=202101022300,
                 in_domain="10YGB----------A",
                 out_domain="10YGB----------A",
+                contract_market_agreement_type="A01",
             )
 
         assert "must be different" in str(exc_info.value)

--- a/tests/test_eic_validation.py
+++ b/tests/test_eic_validation.py
@@ -99,17 +99,18 @@ class TestEICValidation:
 
     def test_balancing_eic_validation_bidding_zone(self):
         """Test EIC validation in specific parameter classes."""
-        # Should raise ValidationError for invalid bidding_zone_domain
+        # Should raise ValidationError for invalid control_area_domain
         with pytest.raises(ValidationError) as exc_info:
             VolumesAndPricesOfContractedReserves(
                 period_start=202012312300,
                 period_end=202101022300,
-                bidding_zone_domain="INVALID_EIC",
+                control_area_domain="INVALID_EIC",
+                type_marketagreement_type="A01",
                 process_type="A52",
             )
 
         assert "Invalid EIC code 'INVALID_EIC'" in str(exc_info.value)
-        assert "bidding_zone_domain" in str(exc_info.value)
+        assert "control_area_domain" in str(exc_info.value)
 
     def test_market_class_eic_validation(self):
         """Test EIC validation in Market-derived classes."""


### PR DESCRIPTION
This Release mainly fixes inconcistencies in the python classes to align them with the API.

Also:
- Increases timeout default to 20 seconds
- Sets the supported python versions to 3.11 - 3.13, see #117  