### PR TITLE
Provide entsoe-apy as flake output

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -211,3 +211,4 @@ pyrightconfig.json
 misc/TransparencyPlatformRestfulAPI.postman_collection.json
 
 *.zip
+result

--- a/flake.nix
+++ b/flake.nix
@@ -41,7 +41,7 @@
             description = pyproject.project.description;
             homepage = pyproject.project.urls.Homepage;
             license = licenses.gpl3Only;
-            maintainers = [ BerriJ ];
+            maintainers = with lib.maintainers; [ berrij ];
             platforms = platforms.all;
           };
         };

--- a/flake.nix
+++ b/flake.nix
@@ -13,9 +13,42 @@
         inherit system;
       };
       pypkgs = pkgs.python313Packages;
+      pyproject = fromTOML (builtins.readFile ./pyproject.toml);
     in
     {
-      devShells.${system}.default = pkgs.mkShell rec {
+      packages.${system} = rec {
+        default = pypkgs.buildPythonPackage {
+          pname = pyproject.project.name;
+          version = pyproject.project.version;
+          pyproject = true;
+
+          src = self;
+
+          build-system = [ pypkgs.setuptools ];
+
+          dependencies = with pypkgs; [
+            httpx
+            loguru
+            xsdata-pydantic
+            isodate
+          ];
+
+          nativeCheckInputs = [ pypkgs.pytestCheckHook ];
+
+          pythonImportsCheck = [ "entsoe" ];
+
+          meta = with pkgs.lib; {
+            description = pyproject.project.description;
+            homepage = pyproject.project.urls.Homepage;
+            license = licenses.gpl3Only;
+            maintainers = [ BerriJ ];
+            platforms = platforms.all;
+          };
+        };
+        entsoe-apy = default;
+      };
+
+      devShells.${system}.default = pkgs.mkShell {
         name = "Python";
         venvDir = "./.venv";
         buildInputs = [


### PR DESCRIPTION
This pull request updates the `flake.nix` file to add support for building and packaging the Python project using Nix, based on metadata from `pyproject.toml`. The main changes center around introducing a Nix package definition for the project, alongside improvements to maintainability and alignment with Python packaging standards.

**Python packaging and Nix integration:**

* Added a new `packages.${system}` attribute that defines a Nix package for the project using `buildPythonPackage`, with metadata (name, version, description, homepage) sourced from `pyproject.toml` for consistency.
* Specified build system and dependencies (`setuptools`, `httpx`, `loguru`, `xsdata-pydantic`, `isodate`) for the Python package, ensuring all required libraries are included.
* Set up test hooks and import checks (`pytestCheckHook`, `pythonImportsCheck`) to validate the package during build.
* Defined package metadata such as license, maintainers, and supported platforms to improve discoverability and compliance.
* Retained and updated the development shell configuration under `devShells.${system}.default`, ensuring a consistent development environment.