### PR TITLE
Don't warn about missing api key at package loading

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
   {name="Jonathan Berrisch", email="jonathan.berrisch@uni-due.de"},
   {name="Jie Xu", email="jie.xu@uni-due.de"}
 ]
-version = "0.9.0"
+version = "0.9.1"
 description = "A Python library for accessing ENTSO-E Transparency Platform API endpoints"
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/src/entsoe/config/config.py
+++ b/src/entsoe/config/config.py
@@ -138,13 +138,6 @@ class EntsoEConfig:
             security_token = env_token
             logger.success("Security token loaded from environment.")
 
-        if security_token is None:
-            logger.warning(
-                "Security token not provided. Please provide it explicitly using "
-                'entsoe.set_config("<security_token>") or set '
-                "the ENTSOE_API environment variable."
-            )
-
         # Validate security token format (UUID)
         if security_token is not None:
             try:


### PR DESCRIPTION
This pull request makes a minor change to the `src/entsoe/config/config.py` file by removing the warning message that was previously shown when a security token was not provided. This streamlines the initialization process and avoids unnecessary log output.

Closes #127 