### PR TITLE
Catch xml parsing errors

### DIFF
--- a/src/entsoe/Base/Base.py
+++ b/src/entsoe/Base/Base.py
@@ -77,6 +77,9 @@ class Base:
         if eic_code is None:
             return  # Skip validation if parameter is not provided
 
+        if eic_code in mappings:
+            return  # Known codes from mappings are always valid
+
         if len(eic_code) != 16:
             raise ValidationError(
                 f"Invalid EIC code '{eic_code}' for parameter '{parameter_name}'. "

--- a/src/entsoe/query/decorators.py
+++ b/src/entsoe/query/decorators.py
@@ -514,6 +514,40 @@ def retry(func):
     return retry_wrapper
 
 
+def handle_parse_error(func):
+    """
+    Decorator that catches parse errors during XML response parsing.
+
+    If any exception occurs during parsing, it is logged and None is returned
+    instead of raising the error. This allows the caller to gracefully skip
+    unparseable responses.
+
+    Returns:
+        The original return value, or None if a parse error occurred.
+    """
+
+    @wraps(func)
+    def parse_error_wrapper(*args, **kwargs):
+        logger.trace("handle_parse_error wrapper: Enter")
+        try:
+            result = func(*args, **kwargs)
+            logger.trace("handle_parse_error wrapper: Exit")
+            return result
+        except Exception as e:
+            # Try to extract filename from the response argument
+            response = args[0] if args else kwargs.get("response")
+            filename = None
+            if response is not None:
+                filename = response.headers.get("X-Filename")
+            if filename:
+                logger.error(f"Parse error in {filename}: {e}")
+            else:
+                logger.error(f"Parse error: {e}")
+            return None
+
+    return parse_error_wrapper
+
+
 def rate_limit(max_calls: int, period: float | int):
     """
     Decorator that enforces a rate limit on function calls.

--- a/src/entsoe/query/decorators.py
+++ b/src/entsoe/query/decorators.py
@@ -556,6 +556,8 @@ def handle_parse_error(func):
             context = f" ({', '.join(context_parts)})" if context_parts else ""
 
             logger.error(f"Parse error: {e}{context}")
+            if response.text is not None:
+                logger.trace(f"Raw XML content:\n{response.text}")
             return None
 
     return parse_error_wrapper

--- a/src/entsoe/query/decorators.py
+++ b/src/entsoe/query/decorators.py
@@ -7,6 +7,7 @@ from itertools import chain
 import re
 import threading
 from time import sleep, time
+from xml.etree.ElementTree import ParseError
 import zipfile
 
 from httpx import RequestError, Response
@@ -533,16 +534,28 @@ def handle_parse_error(func):
             result = func(*args, **kwargs)
             logger.trace("handle_parse_error wrapper: Exit")
             return result
-        except Exception as e:
-            # Try to extract filename from the response argument
+        except ParseError as e:
+            # Try to extract filename and params from the response argument
             response = args[0] if args else kwargs.get("response")
             filename = None
+            params = None
             if response is not None:
                 filename = response.headers.get("X-Filename")
+                if hasattr(response, "request") and response.request is not None:
+                    params = {
+                        k: v
+                        for k, v in response.request.url.params.items()
+                        if k != "securityToken"
+                    }
+
+            context_parts = []
             if filename:
-                logger.error(f"Parse error in {filename}: {e}")
-            else:
-                logger.error(f"Parse error: {e}")
+                context_parts.append(f"file={filename}")
+            if params:
+                context_parts.append(f"params={params}")
+            context = f" ({', '.join(context_parts)})" if context_parts else ""
+
+            logger.error(f"Parse error: {e}{context}")
             return None
 
     return parse_error_wrapper

--- a/src/entsoe/query/query_api.py
+++ b/src/entsoe/query/query_api.py
@@ -9,6 +9,7 @@ from .decorators import (
     check_response_type,
     check_service_unavailable,
     handle_acknowledgement,
+    handle_parse_error,
     pagination,
     rate_limit,
     retry,
@@ -81,6 +82,7 @@ def fetch_responses(params: dict) -> list[Response]:
     return [response]
 
 
+@handle_parse_error
 @handle_acknowledgement
 def parse_response(response: Response) -> BaseModel | None:
     """


### PR DESCRIPTION
Adjust handling of XML parsing:

Parsing errors are not raised anymore; instead, we log an error using loguru and return None. This is necessary to return data if one query returns multiple XML files, where only some of them cause a parsing error. The old behavior raised an error and returned nothing. The new behavior logs an error, so you will notice in the console output, but you will still get the valid responses.

This is necessary as ENTSOE returns some invalid XML responses for Outages like this:

<img width="800" height="220" alt="image" src="https://github.com/user-attachments/assets/4bedbded-84dd-472e-8435-8063d6ff4507" />

The "&" character must be escaped in the above XML. I reported this to ENTSOE, and they are working on resolving this.

Additionally: If a parsing error occurs. We log the Filename of the problematic XML on the DEBUG level and we even log the raw XML content on the TRACE level. 