### PR TITLE
Release 1.0.0

### DIFF
--- a/misc/endpoints/Balancing/12.3.B&C Balancing energy bids archives.json
+++ b/misc/endpoints/Balancing/12.3.B&C Balancing energy bids archives.json
@@ -40,7 +40,7 @@
     {
       "key": "offset",
       "value": "0",
-      "description": "[O] Integer (allows downloading more than 100 documents. The offset must belong to the range [0,4800] so that paging is restricted to query for 4900 documents max., offset=n returns files in sequence between n+1 and n+100)"
+      "description": "[O] Integer: Zero‑based index of the first archive to return. The offset parameter paginates the response in batches of 100 archives (e.g., offset = n returns the archives in the range n+1 to n+100)."
     }
   ]
 }

--- a/misc/endpoints/Balancing/12.3.B&C Balancing energy bids.json
+++ b/misc/endpoints/Balancing/12.3.B&C Balancing energy bids.json
@@ -35,7 +35,7 @@
     {
       "key": "offset",
       "value": "1000",
-      "description": "[O] Integer (allows downloading more than 100 documents. The offset ∈ [0,4800] so that paging is restricted to query for 4900 documents max., offset=n returns files in sequence between n+1 and n+100)",
+      "description": "[O] Integer: Zero‑based index of the first TimeSeries to return. The offset parameter paginates the response in batches of 100 TimeSeries (e.g., offset = n returns the TimeSeries in the range n+1 to n+100).",
       "disabled": true
     },
     {

--- a/misc/endpoints/Balancing/12.3.F Procured balancing capacity (GL EB).json
+++ b/misc/endpoints/Balancing/12.3.F Procured balancing capacity (GL EB).json
@@ -30,7 +30,7 @@
     {
       "key": "offset",
       "value": "0",
-      "description": "[O] Integer (allows downloading more than 100 documents. The offset must belong to the range [0,4800] so that paging is restricted to query for 4900 documents max., offset=n returns files in sequence between n+1 and n+100)"
+      "description": "[O] Integer: Zero‑based index of the first TimeSeries to return. The offset parameter paginates the response in batches of 100 TimeSeries (e.g., offset = n returns the TimeSeries in the range n+1 to n+100)."
     },
     {
       "key": "Type_MarketAgreement.Type",

--- a/misc/endpoints/Balancing/17.1.B&C Volumes and Prices of Contracted Reserves.json
+++ b/misc/endpoints/Balancing/17.1.B&C Volumes and Prices of Contracted Reserves.json
@@ -46,7 +46,7 @@
     {
       "key": "offset",
       "value": "0",
-      "description": "[O] Integer (allows downloading more than 100 documents. The offset must belong to the range [0,4800] so that paging is restricted to query for 4900 documents max., offset=n returns files in sequence between n+1 and n+100)",
+      "description": "[O] Integer: Zero‑based index of the first TimeSeries to return. The offset parameter paginates the response in batches of 100 TimeSeries (e.g., offset = n returns the TimeSeries in the range n+1 to n+100).",
       "disabled": true
     }
   ]

--- a/misc/endpoints/Balancing/190.1 Sharing of RR and FRR (SO GL).json
+++ b/misc/endpoints/Balancing/190.1 Sharing of RR and FRR (SO GL).json
@@ -36,6 +36,11 @@
       "key": "periodEnd",
       "value": "202112310000",
       "description": "Pattern yyyyMMddHHmm e.g. 201601010000"
+    },
+    {
+      "key": "offset",
+      "value": "0",
+      "description": "[O] Integer: Zero‑based index of the first TimeSeries to return. The offset parameter paginates the response in batches of 100 TimeSeries (e.g., offset = n returns the TimeSeries in the range n+1 to n+100)."
     }
   ]
 }

--- a/misc/endpoints/Balancing/190.2 Sharing of FCR between SAs (SO GL).json
+++ b/misc/endpoints/Balancing/190.2 Sharing of FCR between SAs (SO GL).json
@@ -31,6 +31,12 @@
       "key": "periodEnd",
       "value": "201512152300",
       "description": "Pattern yyyyMMddHHmm e.g. 201601010000"
+    },
+    {
+      "key": "offset",
+      "value": "0",
+      "description": "[O] Integer: Zero‑based index of the first TimeSeries to return. The offset parameter paginates the response in batches of 100 TimeSeries (e.g., offset = n returns the TimeSeries in the range n+1 to n+100).",
+      "disabled": true
     }
   ]
 }

--- a/misc/endpoints/Balancing/190.3 Exchanged Reserve Capacity (SO GL).json
+++ b/misc/endpoints/Balancing/190.3 Exchanged Reserve Capacity (SO GL).json
@@ -40,7 +40,7 @@
     {
       "key": "Offset",
       "value": "1",
-      "description": "Offset (allows downloading more than 100 documents. The offset ∈ [0,4800] so that paging is restricted to query for 4900 documents max., offset=n returns files in sequence between n+1 and n+100)",
+      "description": "[O] Integer: Zero‑based index of the first TimeSeries to return. The offset parameter paginates the response in batches of 100 TimeSeries (e.g., offset = n returns the TimeSeries in the range n+1 to n+100).",
       "disabled": true
     }
   ]

--- a/misc/endpoints/Balancing/IFs aFRR 3.4 & mFRR 3.4 Elastic Demands.json
+++ b/misc/endpoints/Balancing/IFs aFRR 3.4 & mFRR 3.4 Elastic Demands.json
@@ -35,7 +35,7 @@
     {
       "key": "offset",
       "value": "0",
-      "description": "[O] Integer (0 - 4800)",
+      "description": "[O] Integer: Zero‑based index of the first TimeSeries to return. The offset parameter paginates the response in batches of 100 TimeSeries (e.g., offset = n returns the TimeSeries in the range n+1 to n+100).",
       "disabled": true
     }
   ]

--- a/misc/endpoints/Balancing/IFs mFRR 9.9, aFRR 9.6&9.8 Changes to Bid Availability.json
+++ b/misc/endpoints/Balancing/IFs mFRR 9.9, aFRR 9.6&9.8 Changes to Bid Availability.json
@@ -36,7 +36,7 @@
     {
       "key": "offset",
       "value": "100",
-      "description": "[O] Integer (0-4800)",
+      "description": "[O] Integer: Zero‑based index of the first TimeSeries to return. The offset parameter paginates the response in batches of 100 TimeSeries (e.g., offset = n returns the TimeSeries in the range n+1 to n+100).",
       "disabled": true
     }
   ]

--- a/misc/endpoints/Market/11.1 Continuous Allocations - Offered Transfer Capacity.json
+++ b/misc/endpoints/Market/11.1 Continuous Allocations - Offered Transfer Capacity.json
@@ -46,7 +46,7 @@
     {
       "key": "offset",
       "value": "0",
-      "description": "[O] Integer (allows downloading more than 100 documents. The offset ∈ [0,4800] so that paging is restricted to query for 4900 documents max., offset=n returns files in sequence between n+1 and n+100)",
+      "description": "[O] Integer: Zero‑based index of the first TimeSeries to return. The offset parameter paginates the response in batches of 100 TimeSeries (e.g., offset = n returns the TimeSeries in the range n+1 to n+100).",
       "disabled": true
     }
   ]

--- a/misc/endpoints/Market/12.1.D Energy Prices.json
+++ b/misc/endpoints/Market/12.1.D Energy Prices.json
@@ -42,7 +42,7 @@
     {
       "key": "offset",
       "value": "0",
-      "description": "[O] Integer (allows downloading more than 100 documents. The offset ∈ [0,4800] so that pagging is restricted to query for 4900 documents max., offset=n returns files in sequence between n+1 and n+100)",
+      "description": "[O] Integer: Zero‑based index of the first TimeSeries to return. The offset parameter paginates the response in batches of 100 TimeSeries (e.g., offset = n returns the TimeSeries in the range n+1 to n+100).",
       "disabled": true
     }
   ]

--- a/misc/endpoints/OMI/Other Market Information.json
+++ b/misc/endpoints/OMI/Other Market Information.json
@@ -43,7 +43,7 @@
     {
       "key": "Offset",
       "value": "12",
-      "description": "[O] Offset allows downloading more than 200 documents. The offset ∈ [0,4800] so that paging is restricted to query for 5000 documents max., offset=n returns files in sequence between n+1 and n+200.",
+      "description": "[O] Integer: Zero‑based index of the first XML document to return. The offset parameter paginates the response in batches of 200 XML documents (e.g., offset = n returns the XMLs in the range n+1 to n+200).",
       "disabled": true
     },
     {

--- a/misc/endpoints/Outages/10.1.A&B Unavailability of Transmission Infrastructure  - Net Position Impact.json
+++ b/misc/endpoints/Outages/10.1.A&B Unavailability of Transmission Infrastructure  - Net Position Impact.json
@@ -55,12 +55,12 @@
     {
       "key": "offset",
       "value": "0",
-      "description": "[O] Integer (allows downloading more than 200 documents. The offset ∈ [0,4800] so that pagging is restricted to query for 5000 documents max., offset=n returns files in sequence between n+1 and n+200)",
+      "description": "[O] Integer: Zero‑based index of the first XML document to return. The offset parameter paginates the response in batches of 200 XML documents (e.g., offset = n returns the XMLs in the range n+1 to n+200).",
       "disabled": true
     },
     {
       "key": "Asset_RegisteredResource.mRID",
-      "value": null,
+      "value": "",
       "description": "EIC Code of the Transmission Asset",
       "disabled": true
     }

--- a/misc/endpoints/Outages/10.1.A&B Unavailability of Transmission Infrastructure - Available Capacity.json
+++ b/misc/endpoints/Outages/10.1.A&B Unavailability of Transmission Infrastructure - Available Capacity.json
@@ -30,7 +30,7 @@
     },
     {
       "key": "Asset_RegisteredResource.mRID",
-      "value": null,
+      "value": "",
       "description": "[O] EIC code of a Transmission Asset",
       "disabled": true
     },
@@ -61,7 +61,7 @@
     {
       "key": "offset",
       "value": "0",
-      "description": "[O] Integer (allows downloading more than 200 documents. The offset ∈ [0,4800] so that pagging is restricted to query for 5000 documents max., offset=n returns files in sequence between n+1 and n+200)",
+      "description": "[O] Integer: Zero‑based index of the first XML document to return. The offset parameter paginates the response in batches of 200 XML documents (e.g., offset = n returns the XMLs in the range n+1 to n+200).",
       "disabled": true
     }
   ]

--- a/misc/endpoints/Outages/10.1.A&B Unavailability of Transmission Infrastructure.json
+++ b/misc/endpoints/Outages/10.1.A&B Unavailability of Transmission Infrastructure.json
@@ -60,7 +60,7 @@
     {
       "key": "offset",
       "value": "0",
-      "description": "[O] Integer (allows downloading more than 200 documents. The offset ∈ [0,4800] so that pagging is restricted to query for 5000 documents max., offset=n returns files in sequence between n+1 and n+200)",
+      "description": "[O] Integer: Zero‑based index of the first XML document to return. The offset parameter paginates the response in batches of 200 XML documents (e.g., offset = n returns the XMLs in the range n+1 to n+200).",
       "disabled": true
     }
   ]

--- a/misc/endpoints/Outages/10.1.C Unavailability of Offshore Grid Infrastructure.json
+++ b/misc/endpoints/Outages/10.1.C Unavailability of Offshore Grid Infrastructure.json
@@ -49,7 +49,7 @@
     {
       "key": "offset",
       "value": "0",
-      "description": "[O] Integer (allows downloading more than 200 documents. The offset ∈ [0,4800] so that pagging is restricted to query for 5000 documents max., offset=n returns files in sequence between n+1 and n+200)",
+      "description": "[O] Integer: Zero‑based index of the first XML document to return. The offset parameter paginates the response in batches of 200 XML documents (e.g., offset = n returns the XMLs in the range n+1 to n+200).",
       "disabled": true
     }
   ]

--- a/misc/endpoints/Outages/15.1.A&B Unavailability of Generation Units.json
+++ b/misc/endpoints/Outages/15.1.A&B Unavailability of Generation Units.json
@@ -61,7 +61,7 @@
     {
       "key": "offset",
       "value": "0",
-      "description": "[O] Integer (Enables downloading more than 200 documents. The offset ∈ [0,4800] so that paging is restricted to query for 5000 documents max., offset=n returns files in sequence between n+1 and n+200)",
+      "description": "[O] Integer: Zero‑based index of the first XML document to return. The offset parameter paginates the response in batches of 200 XML documents (e.g., offset = n returns the XMLs in the range n+1 to n+200).",
       "disabled": true
     }
   ]

--- a/misc/endpoints/Outages/15.1.C-D Unavailability of Production Units.json
+++ b/misc/endpoints/Outages/15.1.C-D Unavailability of Production Units.json
@@ -61,7 +61,7 @@
     {
       "key": "offset",
       "value": "1",
-      "description": "[O] Integer (allows downloading more than 100 documents. The offset ∈ [0,4800] so that pagging is restricted to query for 5000 documents max., offset=n returns files in sequence between n+1 and n+100)",
+      "description": "[O] Integer: Zero‑based index of the first XML document to return. The offset parameter paginates the response in batches of 200 XML documents (e.g., offset = n returns the XMLs in the range n+1 to n+200).",
       "disabled": true
     }
   ]

--- a/misc/endpoints/Outages/Fall-backs [IFs IN 7.2, mFRR 3.11, aFRR 3.10].json
+++ b/misc/endpoints/Outages/Fall-backs [IFs IN 7.2, mFRR 3.11, aFRR 3.10].json
@@ -40,8 +40,14 @@
     },
     {
       "key": "mRID",
-      "value": null,
+      "value": "",
       "description": "[O] Used to retrieve previous publication versions",
+      "disabled": true
+    },
+    {
+      "key": "offset",
+      "value": "0",
+      "description": "[O] Integer: Zero‑based index of the first XML document to return. The offset parameter paginates the response in batches of 100 XML documents (e.g., offset = n returns the XMLs in the range n+1 to n+100).",
       "disabled": true
     }
   ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
   {name="Jonathan Berrisch", email="jonathan.berrisch@uni-due.de"},
   {name="Jie Xu", email="jie.xu@uni-due.de"}
 ]
-version = "0.9.2"
+version = "1.0.0"
 description = "A Python library for accessing ENTSO-E Transparency Platform API endpoints"
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/src/entsoe/Base/Base.py
+++ b/src/entsoe/Base/Base.py
@@ -77,6 +77,9 @@ class Base:
         if eic_code is None:
             return  # Skip validation if parameter is not provided
 
+        if eic_code in mappings:
+            return  # Known codes from mappings are always valid
+
         if len(eic_code) != 16:
             raise ValidationError(
                 f"Invalid EIC code '{eic_code}' for parameter '{parameter_name}'. "

--- a/src/entsoe/OMI/OMI.py
+++ b/src/entsoe/OMI/OMI.py
@@ -4,6 +4,9 @@ from ..Base.Base import Base
 
 
 class OMI(Base):
+    # OMI paginates in batches of 200 XML documents
+    offset_increment: int = 200
+
     """Other Market Information (OMI) parameters for ENTSO-E Transparency
     Platform queries."""
 

--- a/src/entsoe/OMI/OMI.py
+++ b/src/entsoe/OMI/OMI.py
@@ -9,6 +9,7 @@ class OMI(Base):
 
     # OMI paginates in batches of 200 XML documents
     offset_increment: int = 200
+
     def __init__(
         self,
         control_area_domain: str,  # Required - EIC code of Scheduling Area

--- a/src/entsoe/OMI/OMI.py
+++ b/src/entsoe/OMI/OMI.py
@@ -4,12 +4,11 @@ from ..Base.Base import Base
 
 
 class OMI(Base):
-    # OMI paginates in batches of 200 XML documents
-    offset_increment: int = 200
-
     """Other Market Information (OMI) parameters for ENTSO-E Transparency
     Platform queries."""
 
+    # OMI paginates in batches of 200 XML documents
+    offset_increment: int = 200
     def __init__(
         self,
         control_area_domain: str,  # Required - EIC code of Scheduling Area

--- a/src/entsoe/Outages/specific_params.py
+++ b/src/entsoe/Outages/specific_params.py
@@ -333,6 +333,9 @@ class UnavailabilityOfOffshoreGridInfrastructure(Outages):
 class Fallbacks(Outages):
     """Parameters for Fall-backs [IFs IN 7.2, mFRR 3.11, aFRR 3.10].
 
+    Note: Unlike other Outages endpoints that paginate in batches of 200,
+    Fall-backs paginates in batches of 100.
+
     Data view:
     https://transparency.entsoe.eu/outage-domain/r2/unavailabilityInTransmissionGrid/show
 
@@ -355,6 +358,7 @@ class Fallbacks(Outages):
     """
 
     code = "Fall-backs"
+    offset_increment: int = 100
 
     def __init__(
         self,

--- a/src/entsoe/query/decorators.py
+++ b/src/entsoe/query/decorators.py
@@ -191,6 +191,7 @@ def unzip(func):
                         headers={
                             **response.headers,
                             "Content-Type": "text/xml; charset=utf-8",
+                            "X-Filename": file_name,
                         },
                         content=xml_content.encode("utf-8"),
                         request=response.request,

--- a/src/entsoe/query/decorators.py
+++ b/src/entsoe/query/decorators.py
@@ -514,6 +514,40 @@ def retry(func):
     return retry_wrapper
 
 
+def handle_parse_error(func):
+    """
+    Decorator that catches parse errors during XML response parsing.
+
+    If any exception occurs during parsing, it is logged and None is returned
+    instead of raising the error. This allows the caller to gracefully skip
+    unparseable responses.
+
+    Returns:
+        The original return value, or None if a parse error occurred.
+    """
+
+    @wraps(func)
+    def parse_error_wrapper(*args, **kwargs):
+        logger.trace("handle_parse_error wrapper: Enter")
+        try:
+            result = func(*args, **kwargs)
+            logger.trace("handle_parse_error wrapper: Exit")
+            return result
+        except Exception as e:
+            # Try to extract filename from the response argument
+            response = args[0] if args else kwargs.get("response")
+            filename = None
+            if response is not None:
+                filename = response.headers.get("X-Filename")
+            if filename:
+                logger.error(f"Parse error in {filename}: {e}")
+            else:
+                logger.error(f"Parse error: {e}")
+            return None
+
+    return parse_error_wrapper
+
+
 def rate_limit(max_calls: int, period: float | int):
     """
     Decorator that enforces a rate limit on function calls.

--- a/src/entsoe/query/decorators.py
+++ b/src/entsoe/query/decorators.py
@@ -556,6 +556,8 @@ def handle_parse_error(func):
             context = f" ({', '.join(context_parts)})" if context_parts else ""
 
             logger.error(f"Parse error: {e}{context}")
+            if response.text is not None:
+                logger.trace(f"Raw XML content:\n{response.text}")
             return None
 
     return parse_error_wrapper

--- a/src/entsoe/query/decorators.py
+++ b/src/entsoe/query/decorators.py
@@ -7,6 +7,7 @@ from itertools import chain
 import re
 import threading
 from time import sleep, time
+from xml.etree.ElementTree import ParseError
 import zipfile
 
 from httpx import RequestError, Response
@@ -533,16 +534,28 @@ def handle_parse_error(func):
             result = func(*args, **kwargs)
             logger.trace("handle_parse_error wrapper: Exit")
             return result
-        except Exception as e:
-            # Try to extract filename from the response argument
+        except ParseError as e:
+            # Try to extract filename and params from the response argument
             response = args[0] if args else kwargs.get("response")
             filename = None
+            params = None
             if response is not None:
                 filename = response.headers.get("X-Filename")
+                if hasattr(response, "request") and response.request is not None:
+                    params = {
+                        k: v
+                        for k, v in response.request.url.params.items()
+                        if k != "securityToken"
+                    }
+
+            context_parts = []
             if filename:
-                logger.error(f"Parse error in {filename}: {e}")
-            else:
-                logger.error(f"Parse error: {e}")
+                context_parts.append(f"file={filename}")
+            if params:
+                context_parts.append(f"params={params}")
+            context = f" ({', '.join(context_parts)})" if context_parts else ""
+
+            logger.error(f"Parse error: {e}{context}")
             return None
 
     return parse_error_wrapper

--- a/src/entsoe/query/decorators.py
+++ b/src/entsoe/query/decorators.py
@@ -374,10 +374,9 @@ def pagination(func):
         logger.info(f"Starting pagination with increment={offset_increment}")
 
         merged_result = []
+        offset = 0
 
-        for offset in range(
-            0, 4801, offset_increment
-        ):  # 0 to 4800 in increments of offset_increment
+        while True:
             params["offset"] = offset
             logger.trace(f"Fetching page at offset {offset}")
 
@@ -390,6 +389,7 @@ def pagination(func):
             # Add results to accumulated list
             merged_result.extend(result)
             logger.trace(f"Retrieved {len(result)} results at offset {offset}")
+            offset += offset_increment
 
         logger.debug(f"Pagination completed with {len(merged_result)} total results")
         logger.trace("pagination wrapper: Exit")

--- a/src/entsoe/query/decorators.py
+++ b/src/entsoe/query/decorators.py
@@ -517,14 +517,14 @@ def retry(func):
 
 def handle_parse_error(func):
     """
-    Decorator that catches parse errors during XML response parsing.
+    Decorator that catches XML parse errors during response parsing.
 
-    If any exception occurs during parsing, it is logged and None is returned
-    instead of raising the error. This allows the caller to gracefully skip
-    unparseable responses.
+    If an ``xml.etree.ElementTree.ParseError`` occurs during parsing, it is
+    logged and ``None`` is returned instead of raising the error. This allows
+    the caller to gracefully skip responses that cannot be parsed.
 
     Returns:
-        The original return value, or None if a parse error occurred.
+        The original return value, or ``None`` if a ``ParseError`` occurred.
     """
 
     @wraps(func)

--- a/src/entsoe/query/query_api.py
+++ b/src/entsoe/query/query_api.py
@@ -9,6 +9,7 @@ from .decorators import (
     check_response_type,
     check_service_unavailable,
     handle_acknowledgement,
+    handle_parse_error,
     pagination,
     rate_limit,
     retry,
@@ -81,6 +82,7 @@ def fetch_responses(params: dict) -> list[Response]:
     return [response]
 
 
+@handle_parse_error
 @handle_acknowledgement
 def parse_response(response: Response) -> BaseModel | None:
     """

--- a/src/entsoe/query/query_api.py
+++ b/src/entsoe/query/query_api.py
@@ -101,10 +101,11 @@ def parse_response(response: Response) -> BaseModel | None:
     logger.trace("parse_response: Enter")
     logger.debug(f"Parsing response with status {response.status_code}")
 
-    name, matching_class = extract_namespace_and_find_classes(response)
+    _filename = response.headers.get("X-Filename")
+    if _filename:
+        logger.debug(f"File: {_filename}")
 
-    class_name = matching_class.__name__ if matching_class else None
-    logger.debug(f"Extracted namespace: {name}, matching class: {class_name}")
+    _, matching_class = extract_namespace_and_find_classes(response)
 
     xml_model = XmlParser().from_string(response.text, matching_class)
 

--- a/tests/test_pagination.py
+++ b/tests/test_pagination.py
@@ -185,44 +185,66 @@ class TestPaginationOffsetIncrement:
             # The function should have been called
             assert mock_query_parse.called
 
-    def test_pagination_respects_max_offset_with_increment_100(self):
-        """Test that pagination respects max offset of 4800 with increment 100."""
-        mock_func = MagicMock(return_value=[{"data": "test"}])
+    def test_pagination_continues_until_empty_with_increment_100(self):
+        """Test that pagination continues until no results with increment 100."""
+        mock_func = MagicMock()
         decorated_func = pagination(mock_func)
 
         params = {"offset": 0, "documentType": "A25"}
 
-        # Mock to always return data (to test we stop at 4800)
-        mock_func.return_value = [{"data": "test"}]
+        # Return data for 50 pages (offsets 0..4900), then empty
+        total_pages = 50
+        call_count = 0
+
+        def side_effect(p, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= total_pages:
+                return [{"data": f"result_{p['offset']}"}]
+            return []
+
+        mock_func.side_effect = side_effect
 
         token = decorators.offset_increment_ctx.set(100)
         try:
-            decorated_func(params)
+            result = decorated_func(params)
         finally:
             decorators.offset_increment_ctx.reset(token)
 
-        # Should have been called 49 times (0, 100, 200, ..., 4700, 4800)
-        assert mock_func.call_count == 49
-        # Last call should have offset 4800
-        assert mock_func.call_args_list[-1][0][0]["offset"] == 4800
+        # Should have been called 51 times (50 with data + 1 empty)
+        assert mock_func.call_count == 51
+        assert len(result) == 50
+        # Last call should have offset 5000, beyond the old 4800 limit
+        assert mock_func.call_args_list[-1][0][0]["offset"] == 5000
 
-    def test_pagination_respects_max_offset_with_increment_200(self):
-        """Test that pagination respects max offset of 4800 with increment 200."""
-        mock_func = MagicMock(return_value=[{"data": "test"}])
+    def test_pagination_continues_until_empty_with_increment_200(self):
+        """Test that pagination continues until no results with increment 200."""
+        mock_func = MagicMock()
         decorated_func = pagination(mock_func)
 
         params = {"offset": 0, "documentType": "A77"}
 
-        # Mock to always return data (to test we stop at 4800)
-        mock_func.return_value = [{"data": "test"}]
+        # Return data for 30 pages (offsets 0..5800), then empty
+        total_pages = 30
+        call_count = 0
+
+        def side_effect(p, *args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= total_pages:
+                return [{"data": f"result_{p['offset']}"}]
+            return []
+
+        mock_func.side_effect = side_effect
 
         token = decorators.offset_increment_ctx.set(200)
         try:
-            decorated_func(params)
+            result = decorated_func(params)
         finally:
             decorators.offset_increment_ctx.reset(token)
 
-        # Should have been called 25 times (0, 200, 400, ..., 4600, 4800)
-        assert mock_func.call_count == 25
-        # Last call should have offset 4800
-        assert mock_func.call_args_list[-1][0][0]["offset"] == 4800
+        # Should have been called 31 times (30 with data + 1 empty)
+        assert mock_func.call_count == 31
+        assert len(result) == 30
+        # Last call should have offset 6000, beyond the old 4800 limit
+        assert mock_func.call_args_list[-1][0][0]["offset"] == 6000


### PR DESCRIPTION
This Release targets XML parsing errors. Re-Aligns the package code to updated documentation and fixes an issue in the EIC validation.

**XML Parsing**

When XML parsing errors happen, we do not raise an error anymore, see #135. This is necessary to parse and return any remaining valid XML responses. Instead we:

- Print a log message on the `ERROR` level informing about the failed parsing attempt. This message includes the query parameters and the filename so users can further investigate
- Print the raw XML on the `TRACE` level so you can directly inspect the XML content

**Offset Parameter**

ENTSOE removed the upper limit for the offset parameter, which was 4800 before. Now we increase the offset parameter until we receive a response that returns no data. For two endpoints, we also adjusted the offset_increment to align with the updated documentation, see #134.

**EIC Validation**

We do not validate EIC codes that are present in the [mappings dictionary](https://entsoe-apy.berrisch.biz/mappings/) anymore, as three of them are not valid according to the checksum calculation but are accepted by API endpoints.