### PR TITLE
Handle time zones and expose format_entsoe_datetime to user as helper function

### DIFF
--- a/docs/examples.md
+++ b/docs/examples.md
@@ -35,6 +35,37 @@ df = DataFrame(records)
 
 See also [Utilities](./utilities.md) for more details on the utility functions.
 
+### Working with datetime and timezones
+
+The ENTSO-E API is (usually) expecting UTC timestamps but the European power markets operate on a Europe/Berlin basis. We can use the `parse_entsoe_datetime` function to convert `datetime` and `pandas` timestamps in the API interface. The function handles time zone information and parses `datetime` derived types to the respective integer. Timezone-naive timestamps are assumed to be in UTC.
+
+```python
+import pandas as pd
+from entsoe.Market import EnergyPrices
+from entsoe.utils import (
+    extract_records, 
+    add_timestamps, 
+    format_entsoe_datetime
+)
+
+period_start = pd.Timestamp("2024-02-01", tz="Europe/Berlin")
+period_end = pd.Timestamp("2024-02-02", tz="Europe/Berlin")
+
+# Query energy prices
+result = EnergyPrices(
+    in_domain="10YNL----------L", # Netherlands
+    out_domain="10YNL----------L",
+    period_start=format_entsoe_datetime(period_start),
+    period_end=format_entsoe_datetime(period_end),
+).query_api()
+
+records = extract_records(result)
+records = add_timestamps(records)
+df = pd.DataFrame(records)
+df = df.convert_dtypes()
+```
+
+
 ### Extracting Specific Domains
 
 You can extract specific parts of the result by specifying a domain:

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -1,3 +1,5 @@
 ::: entsoe.utils.extract_records
 
 ::: entsoe.utils.add_timestamps
+
+::: entsoe.utils.convert

--- a/docs/utilities.md
+++ b/docs/utilities.md
@@ -2,4 +2,4 @@
 
 ::: entsoe.utils.add_timestamps
 
-::: entsoe.utils.convert
+::: entsoe.utils.format_entsoe_datetime

--- a/src/entsoe/utils/__init__.py
+++ b/src/entsoe/utils/__init__.py
@@ -8,5 +8,5 @@ __all__ = [
     "extract_records",
     "add_timestamps",
     "calculate_timestamp",
-    "format_entsoe_datetime"
+    "format_entsoe_datetime",
 ]

--- a/src/entsoe/utils/__init__.py
+++ b/src/entsoe/utils/__init__.py
@@ -1,5 +1,12 @@
 from .mappings_dict import mappings
 from .records import extract_records
 from .timestamps import add_timestamps, calculate_timestamp
+from .utils import format_entsoe_datetime
 
-__all__ = ["mappings", "extract_records", "add_timestamps", "calculate_timestamp"]
+__all__ = [
+    "mappings",
+    "extract_records",
+    "add_timestamps",
+    "calculate_timestamp",
+    "format_entsoe_datetime"
+]

--- a/src/entsoe/utils/utils.py
+++ b/src/entsoe/utils/utils.py
@@ -1,4 +1,4 @@
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 import inspect
 from xml.etree import ElementTree as ET
 
@@ -38,11 +38,11 @@ def format_entsoe_datetime(dt: datetime) -> int:
         Date in YYYYMMDDHHMM format as integer
     """
     if dt.tzinfo is not None:
-        utc_timestamp = dt - dt.tzinfo.utcoffset(dt)
+        utc_timestamp = dt.astimezone(timezone.utc)
         return int(utc_timestamp.strftime("%Y%m%d%H%M"))
     else:
         # Assume naive timestamps are in UTC
-        return int(dt.strftime("%Y%m%d%H%M"))       
+        return int(dt.strftime("%Y%m%d%H%M"))
 
 
 def check_date_range_limit(

--- a/src/entsoe/utils/utils.py
+++ b/src/entsoe/utils/utils.py
@@ -37,7 +37,12 @@ def format_entsoe_datetime(dt: datetime) -> int:
     Returns:
         Date in YYYYMMDDHHMM format as integer
     """
-    return int(dt.strftime("%Y%m%d%H%M"))
+    if dt.tzinfo is not None:
+        utc_timestamp = dt - dt.tzinfo.utcoffset(dt)
+        return int(utc_timestamp.strftime("%Y%m%d%H%M"))
+    else:
+        # Assume naive timestamps are in UTC
+        return int(dt.strftime("%Y%m%d%H%M"))       
 
 
 def check_date_range_limit(

--- a/src/entsoe/utils/utils.py
+++ b/src/entsoe/utils/utils.py
@@ -31,6 +31,12 @@ def format_entsoe_datetime(dt: datetime) -> int:
     """
     Format datetime object to ENTSOE datetime format (YYYYMMDDHHMM).
 
+    Convert a (tz-aware) datetime to UTC and format it as an integer in the 
+    ENTSOE format. If the datetime is naive, it is assumed to be in UTC.This 
+    function can be used to convert pd.Timestamp and pl.Datetime objects to the 
+    required format for ENTSOE API calls. Please have a look at the 
+    documentation for more details and examples.
+
     Args:
         dt: datetime object
 


### PR DESCRIPTION
The ENTSO-API is in UTC, but the package does not handle timezones well. I propose to expose the `format_entsoe_datetime`  to the user and add some basic TZ functionality.

It would be nice to be able to do:

```python
from pandas import DataFrame
from entsoe.Market import EnergyPrices
from entsoe.utils import extract_records, add_timestamps
from entsoe.utils import format_entsoe_datetime

period_start = pd.Timestamp("2024-02-01", tz="Europe/Berlin")
period_end = pd.Timestamp("2024-02-02", tz="Europe/Berlin")

# Query energy prices
result = EnergyPrices(
    in_domain="10YNL----------L", # Netherlands
    out_domain="10YNL----------L",
    period_start=format_entsoe_datetime(period_start),
    period_end=format_entsoe_datetime(period_end),
).query_api()

```
but currently, you have:

```python
from entsoe.utils.utils import format_entsoe_datetime
import datetime as dt
import zoneinfo
import pandas as pd

ts_dt_0 = dt.datetime(2024, 2, 2)
ts_dt_1 = dt.datetime(2024, 2, 2, tzinfo=zoneinfo.ZoneInfo("UTC"))
ts_dt_2 = dt.datetime(2024, 2, 2, tzinfo=zoneinfo.ZoneInfo("Europe/Berlin"))

# %%
format_entsoe_datetime(ts_dt_0), format_entsoe_datetime(ts_dt_1), format_entsoe_datetime(ts_dt_2)
# (202402020000, 202402020000, 202402020000)
```
so I propose to make the function tz aware by a simple 

```python
def format_entsoe_datetime(dt: datetime) -> int:
    """
    Format datetime object to ENTSOE datetime format (YYYYMMDDHHMM).

    Args:
        dt: datetime object

    Returns:
        Date in YYYYMMDDHHMM format as integer
    """
    if dt.tzinfo is not None:
        utc_timestamp = dt.astimezone(timezone.utc)
        return int(utc_timestamp.strftime("%Y%m%d%H%M"))
    else:
        # Assume naive timestamps are in UTC
        return int(dt.strftime("%Y%m%d%H%M"))
```
and expose the function to the user for simplicity. If you agree, I'd add a few sentences on timezones to the documentation as well