### PR TITLE
Fix normalize_to_records function 

### DIFF
--- a/src/entsoe/utils/records.py
+++ b/src/entsoe/utils/records.py
@@ -69,14 +69,18 @@ def normalize_to_records(
         return {k: v for k, v in record.items() if k not in ignore_fields}
 
     if isinstance(data, dict):
-        items = {}
+        items: Dict[str, Any] = {}
+        expansions: List[List[Dict[str, Any]]] = []
         for k, v in data.items():
             new_key = f"{parent_key}{sep}{k}" if parent_key else k
             if isinstance(v, dict):
                 sub_records = normalize_to_records(
                     v, new_key, sep=sep, ignore_fields=ignore_fields
                 )
-                items.update(sub_records[0])  # merge dict
+                if len(sub_records) == 1:
+                    items.update(sub_records[0])
+                elif len(sub_records) > 1:
+                    expansions.append(sub_records)
             elif isinstance(v, list):
                 # Expand list elements into multiple records
                 list_records = []
@@ -88,14 +92,15 @@ def normalize_to_records(
                         list_records.extend(sub_records)
                     else:
                         list_records.append({new_key: elem})
-                # Cross join if multiple records, else just keep one
                 if list_records:
-                    return [
-                        _filter_ignored_fields(dict(items, **lr)) for lr in list_records
-                    ]
+                    expansions.append(list_records)
             else:
                 items[new_key] = v
-        return [_filter_ignored_fields(items)]
+        # Cross-join base items with all collected expansions
+        result: List[Dict[str, Any]] = [items]
+        for expansion in expansions:
+            result = [dict(r, **e) for r in result for e in expansion]
+        return [_filter_ignored_fields(r) for r in result]
     elif isinstance(data, list):
         records = []
         for elem in data:

--- a/tests/test_normalize_to_records.py
+++ b/tests/test_normalize_to_records.py
@@ -1,7 +1,5 @@
 """Unit tests for the normalize_to_records function."""
 
-import pytest
-
 from entsoe.utils.records import normalize_to_records
 
 
@@ -78,9 +76,7 @@ def test_nested_dict_containing_list_produces_sub_records():
         },
     }
     result = normalize_to_records(data)
-    assert len(result) == 2, (
-        "Expected one record per element in the nested dict's list"
-    )
+    assert len(result) == 2, "Expected one record per element in the nested dict's list"
     assert {"ts_id": "ts-1", "group.label": "g1", "group.items.id": "a"} in result
     assert {"ts_id": "ts-1", "group.label": "g1", "group.items.id": "b"} in result
 

--- a/tests/test_normalize_to_records.py
+++ b/tests/test_normalize_to_records.py
@@ -1,0 +1,117 @@
+"""Unit tests for the normalize_to_records function."""
+
+import pytest
+
+from entsoe.utils.records import normalize_to_records
+
+
+def test_flat_dict():
+    """Flat dict produces a single record."""
+    data = {"a": 1, "b": "x"}
+    result = normalize_to_records(data)
+    assert result == [{"a": 1, "b": "x"}]
+
+
+def test_nested_dict_flattened():
+    """Nested dict is flattened with dot-notation keys."""
+    data = {"a": {"b": 1, "c": 2}}
+    result = normalize_to_records(data)
+    assert result == [{"a.b": 1, "a.c": 2}]
+
+
+def test_list_expands_to_multiple_records():
+    """A top-level list field expands into one record per element."""
+    data = {"name": "series", "points": [{"v": 1}, {"v": 2}, {"v": 3}]}
+    result = normalize_to_records(data)
+    assert len(result) == 3
+    assert {"name": "series", "points.v": 1} in result
+    assert {"name": "series", "points.v": 2} in result
+    assert {"name": "series", "points.v": 3} in result
+
+
+def test_nested_list_in_time_series_entry_not_dropped():
+    """
+    Nested list within a time_series entry must not silently drop data.
+
+    This is the core regression case: a time_series entry that contains a
+    nested list (e.g., production_registering_unit) must expand into multiple
+    records — one per nested element — rather than silently losing all but one.
+    """
+    data = [
+        {
+            "period": "2020-01-01",
+            "production_registering_unit": [
+                {"name": "unit_a", "type": "solar"},
+                {"name": "unit_b", "type": "wind"},
+            ],
+        }
+    ]
+    result = normalize_to_records(data)
+    assert len(result) == 2, (
+        "Expected one record per nested list element; nested data must not be dropped"
+    )
+    assert {
+        "period": "2020-01-01",
+        "production_registering_unit.name": "unit_a",
+        "production_registering_unit.type": "solar",
+    } in result
+    assert {
+        "period": "2020-01-01",
+        "production_registering_unit.name": "unit_b",
+        "production_registering_unit.type": "wind",
+    } in result
+
+
+def test_nested_dict_containing_list_produces_sub_records():
+    """
+    A dict field that itself contains a list must produce multiple sub-records.
+
+    This covers the case raised in code review: a dict value that expands into
+    more than one sub_record must be collected and cross-joined with the base
+    fields, not silently discarded.
+    """
+    data = {
+        "ts_id": "ts-1",
+        "group": {
+            "label": "g1",
+            "items": [{"id": "a"}, {"id": "b"}],
+        },
+    }
+    result = normalize_to_records(data)
+    assert len(result) == 2, (
+        "Expected one record per element in the nested dict's list"
+    )
+    assert {"ts_id": "ts-1", "group.label": "g1", "group.items.id": "a"} in result
+    assert {"ts_id": "ts-1", "group.label": "g1", "group.items.id": "b"} in result
+
+
+def test_cross_join_of_multiple_list_fields():
+    """Multiple list fields at the same level are cross-joined."""
+    data = {
+        "colors": [{"c": "red"}, {"c": "blue"}],
+        "sizes": [{"s": "S"}, {"s": "M"}],
+    }
+    result = normalize_to_records(data)
+    assert len(result) == 4
+    assert {"colors.c": "red", "sizes.s": "S"} in result
+    assert {"colors.c": "red", "sizes.s": "M"} in result
+    assert {"colors.c": "blue", "sizes.s": "S"} in result
+    assert {"colors.c": "blue", "sizes.s": "M"} in result
+
+
+def test_ignore_fields_removes_keys():
+    """Fields listed in ignore_fields are excluded from all records."""
+    data = {"m_rid": "secret", "value": 42, "points": [{"v": 1}, {"v": 2}]}
+    result = normalize_to_records(data, ignore_fields=["m_rid"])
+    assert all("m_rid" not in r for r in result)
+    assert len(result) == 2
+
+
+def test_primitive_list_elements():
+    """A list of primitives (not dicts) creates one record per element."""
+    data = {"tags": ["alpha", "beta", "gamma"]}
+    result = normalize_to_records(data)
+    assert len(result) == 3
+    assert {"tags": "alpha"} in result
+    assert {"tags": "beta"} in result
+    assert {"tags": "gamma"} in result


### PR DESCRIPTION
This PR fixes `normalize_to_records`, which did not traverse into nested elements within a time_series entry

Until now, I have not discovered nested elements within a time_series entry, but the ProductionAndGenerationUnits endpoint returns those. This change may increase the number of rows and columns for existing queries, but it is absolutely necessary for not silently dropping data. Endpoints like Load and EnergyPrices are not affected as they do not have nested structures in the `time_series` objects.