### PR TITLE
Update Postman Documentation

### DIFF
--- a/misc/endpoints/Transmission/12.1.F Commercial Schedules - Net Positions.json
+++ b/misc/endpoints/Transmission/12.1.F Commercial Schedules - Net Positions.json
@@ -8,6 +8,11 @@
       "description": "[M] A09 = Finalised schedule"
     },
     {
+      "key": "businessType",
+      "value": "B09",
+      "description": "[M] B09 = Net position"
+    },
+    {
       "key": "out_Domain",
       "value": "10YAT-APG------L",
       "description": "[M] EIC code of a Control Area, Bidding Zone or a Country"

--- a/src/entsoe/Transmission/specific_params.py
+++ b/src/entsoe/Transmission/specific_params.py
@@ -177,6 +177,7 @@ class CommercialSchedulesNetPositions(Transmission):
     Fixed parameters:
 
     - documentType: A09 (Finalised schedule)
+    - businessType: B09 (Net position)
 
     Request Limits:
     - One year range limit applies
@@ -205,6 +206,7 @@ class CommercialSchedulesNetPositions(Transmission):
         # Initialize with preset and user parameters
         super().__init__(
             document_type="A09",
+            business_type="B09",  # Fixed: Net position
             period_start=period_start,
             period_end=period_end,
             in_domain=in_domain,


### PR DESCRIPTION
The postman documentation has changed. This PR updates the local copy and implements the corresponding adjustments in the Python codebase.

- Updated `misc/endpoints/Transmission/12.1.F Commercial Schedules - Net Positions.json` with the latest upstream documentation
- Added mandatory `businessType: B09` (Net position) parameter to the `CommercialSchedulesNetPositions` Python class in `src/entsoe/Transmission/specific_params.py`