### PR TITLE
Release 1.1.1

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -8,6 +8,6 @@ authors:
     given-names: "Jie"
     orcid: "https://orcid.org/0009-0002-1518-8010"
 title: "entsoe-apy: Python Package to Query the ENTSO-E API"
-version: 1.1.0
+version: 1.1.1
 date-released: 2026-05-12
 url: "https://github.com/BerriJ/entsoe-apy"

--- a/misc/endpoints/Transmission/12.1.F Commercial Schedules - Net Positions.json
+++ b/misc/endpoints/Transmission/12.1.F Commercial Schedules - Net Positions.json
@@ -8,6 +8,11 @@
       "description": "[M] A09 = Finalised schedule"
     },
     {
+      "key": "businessType",
+      "value": "B09",
+      "description": "[M] B09 = Net position"
+    },
+    {
       "key": "out_Domain",
       "value": "10YAT-APG------L",
       "description": "[M] EIC code of a Control Area, Bidding Zone or a Country"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
   {name="Jonathan Berrisch", email="jonathan.berrisch@uni-due.de"},
   {name="Jie Xu", email="jie.xu@uni-due.de"}
 ]
-version = "1.1.0"
+version = "1.1.1"
 description = "A Python library for accessing ENTSO-E Transparency Platform API endpoints"
 readme = "README.md"
 license = "GPL-3.0-or-later"

--- a/src/entsoe/Transmission/specific_params.py
+++ b/src/entsoe/Transmission/specific_params.py
@@ -177,6 +177,7 @@ class CommercialSchedulesNetPositions(Transmission):
     Fixed parameters:
 
     - documentType: A09 (Finalised schedule)
+    - businessType: B09 (Net position)
 
     Request Limits:
     - One year range limit applies
@@ -205,6 +206,7 @@ class CommercialSchedulesNetPositions(Transmission):
         # Initialize with preset and user parameters
         super().__init__(
             document_type="A09",
+            business_type="B09",  # Fixed: Net position
             period_start=period_start,
             period_end=period_end,
             in_domain=in_domain,


### PR DESCRIPTION
This is a patch release updating the 12.1.F endpoint with respect. to change upstream docs.

* Added a new entry for `businessType` with value `B09` (Net position) in the endpoint metadata file `12.1.F Commercial Schedules - Net Positions.json`.
* Updated the class docstring in `CommercialSchedulesNetPositions` to document that `businessType: B09` is now a fixed parameter.
* Modified the `CommercialSchedulesNetPositions` class initializer to always set `business_type="B09"` for all requests.